### PR TITLE
fix: replace uuid with uuid-browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "react-router-typesafe-routes": "^1.2.1",
     "react-use": "^17.4.0",
     "superjson": "^1.13.3",
-    "uuid": "^9.0.1",
+    "uuid-browser": "^3.1.0",
     "yup": "^1.3.2",
     "zod": "^3.22.4"
   },
@@ -86,7 +86,7 @@
     "@types/react-beautiful-dnd": "^13.1.5",
     "@types/react-dom": "^18.2.8",
     "@types/react-test-renderer": "^18.0.3",
-    "@types/uuid": "9.0.1",
+    "@types/uuid-browser": "3.1.0",
     "@typescript-eslint/eslint-plugin": "^6.7.5",
     "@typescript-eslint/parser": "^6.7.5",
     "@vitejs/plugin-react": "^4.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,9 +86,9 @@ dependencies:
   superjson:
     specifier: ^1.13.3
     version: 1.13.3
-  uuid:
-    specifier: ^9.0.1
-    version: 9.0.1
+  uuid-browser:
+    specifier: ^3.1.0
+    version: 3.1.0
   yup:
     specifier: ^1.3.2
     version: 1.3.2
@@ -118,9 +118,9 @@ devDependencies:
   '@types/react-test-renderer':
     specifier: ^18.0.3
     version: 18.0.3
-  '@types/uuid':
-    specifier: 9.0.1
-    version: 9.0.1
+  '@types/uuid-browser':
+    specifier: 3.1.0
+    version: 3.1.0
   '@typescript-eslint/eslint-plugin':
     specifier: ^6.7.5
     version: 6.7.5(@typescript-eslint/parser@6.7.5)(eslint@8.51.0)(typescript@5.2.2)
@@ -1432,8 +1432,8 @@ packages:
     resolution: {integrity: sha512-OxepLK9EuNEIPxWNME+C6WwbRAOOI2o2BaQEGzz5Lu2e4Z5eDnEo+/aVEDMIXywoJitJ7xWd641wrGLZdtwRyw==}
     dev: true
 
-  /@types/uuid@9.0.1:
-    resolution: {integrity: sha512-rFT3ak0/2trgvp4yYZo5iKFEPsET7vKydKF+VRCxlQ9bpheehyAJH89dAkaLEq/j/RZXJIqcgsmPJKUP1Z28HA==}
+  /@types/uuid-browser@3.1.0:
+    resolution: {integrity: sha512-H8KMUicLgRzbTpVr7ixXud05rjJ2B6qypNj1utmchqfOH9N2eG9IuzLHsMhoe94Fn+eXGoshnYbP3A1jyzhpmg==}
     dev: true
 
   /@types/verror@1.10.7:
@@ -7419,14 +7419,14 @@ packages:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
     dev: true
 
+  /uuid-browser@3.1.0:
+    resolution: {integrity: sha512-dsNgbLaTrd6l3MMxTtouOCFw4CBFc/3a+GgYA2YyrJvyQ1u6q4pcu3ktLoUZ/VN/Aw9WsauazbgsgdfVWgAKQg==}
+    deprecated: Package no longer supported and required. Use the uuid package or crypto.randomUUID instead
+    dev: false
+
   /uuid@3.4.0:
     resolution: {integrity: sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==}
     deprecated: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
-    hasBin: true
-    dev: false
-
-  /uuid@9.0.1:
-    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
     hasBin: true
     dev: false
 

--- a/src/main/entities/mod/lib/helpers/getModInfo/getModInfo.ts
+++ b/src/main/entities/mod/lib/helpers/getModInfo/getModInfo.ts
@@ -2,7 +2,7 @@ import { rm, writeFile } from "fs/promises";
 import path from "path";
 
 import { load } from "cheerio";
-import { v4 } from "uuid";
+import { v4 } from "uuid-browser";
 
 import { BALDURS_GATE3 } from "@main/shared/config";
 import { netConnection } from "@main/shared/lib/helpers";


### PR DESCRIPTION
* due to compatibility issues and how vite resolves import `uuid` was replaced with `uuid-browser`